### PR TITLE
Use CP "oow" file for weight map

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,6 +85,7 @@ install:
 
 before_script:
     - pwd
+    - export LEGACYZPTS_DIR=$(pwd)
     - export MYCODE=$HOME/mycode
     - sudo rm -rf $HOME/astrometry.net
     - if [ ! -d "$HOME/astrometry.net" ]; then (cd $HOME && curl -SL https://github.com/dstndstn/astrometry.net/releases/download/0.72/astrometry.net-0.72.tar.gz -o astrometry.net.tar.gz && tar -xzf astrometry.net.tar.gz && mv astrometry.net-0.72 astrometry.net); fi
@@ -113,16 +114,19 @@ before_script:
     - export PYTHONPATH=$HOME/theValidator:$PYTHONPATH
     # - cd $HOME && git clone https://github.com/legacysurvey/legacyzpts.git
     #- export PYTHONPATH=$HOME/legacyzpts/py:$PYTHONPATH
-    - export PYTHONPATH=${PYTHONPATH}:.
+    - export PYTHONPATH=${PYTHONPATH}:${LEGACYZPTS_DIR}/py:.
     - echo PYTHONPATH is $PYTHONPATH
 
 script:
   - pwd
-  #- cd $HOME/legacyzpts
+  - cd $LEGACYZPTS_DIR
+  - pwd
+  - find .
   - pytest -v tests/test_run.py::test_main 
   - pytest -v tests/test_against_surveyccds.py::test_main 
   - pytest -v tests/test_against_idl.py::test_main
-  #- coverage run --source py/legacyzpts tests/test_run.py
+  - coverage run --source py/legacyzpts tests/test_run.py
+  - find .
 
 after_success:
   - coverage report

--- a/py/legacyzpts/fetch.py
+++ b/py/legacyzpts/fetch.py
@@ -21,6 +21,8 @@ def fetch_targz(targz_url, outdir):
         print('Grabbing: %s\n Putting here: %s' % (targz_url,outfn))
         urllib.request.urlretrieve(targz_url, outfn)
         tgz = tarfile.open(outfn)
+        print('Tarfile contents:')
+        tgz.list()
         tgz.extractall(path= outdir)
         tgz.close()
     else:

--- a/py/legacyzpts/legacy_zeropoints.py
+++ b/py/legacyzpts/legacy_zeropoints.py
@@ -2187,7 +2187,6 @@ class Measurer(object):
             return
 
         from legacypipe.survey import LegacySurveyData
-        from legacypipe.decam import DecamImage
 
         class FakeLegacySurveyData(LegacySurveyData):
             def get_calib_dir(self):

--- a/py/legacyzpts/legacy_zeropoints.py
+++ b/py/legacyzpts/legacy_zeropoints.py
@@ -1109,6 +1109,21 @@ class Measurer(object):
         self.bitmask= self.read_bitmask()
         weight = self.read_weight()
 
+        plt.clf()
+        n,b,p = plt.hist(((self.img - np.median(self.img)) * np.sqrt(weight))[weight > 0],
+                         range=(-6,6), bins=100)
+        plt.xlabel('Image pixel chi')
+        xx = np.linspace(-6,6, 100)
+        yy = 1./np.sqrt(2.*np.pi) * np.exp(-0.5 * xx**2)
+        yy *= sum(n)
+        db = b[1]-b[0]
+        plt.plot(xx, yy * db, 'r-')
+        plt.xlim(-6,6)
+        fn = 'chipre-%i-%s.png' % (self.expnum, self.ccdname)
+        plt.savefig(fn)
+        print('Wrote', fn)
+
+
         self.invvar = self.remap_invvar(weight, self.primhdr, self.img, self.bitmask)
 
         t0= ptime('read image',t0)
@@ -1357,12 +1372,28 @@ class Measurer(object):
 
             ierr = np.sqrt(self.invvar)
 
-            # plt.clf()
-            # plt.hist((fit_img * ierr).ravel(), range=(-10,10), bins=100)
-            # plt.xlabel('Image pixel chi')
-            # fn = 'chi-%i-%s.png' % (self.expnum, self.ccdname)
-            # plt.savefig(fn)
-            # print('Wrote', fn)
+            plt.clf()
+            n,b,p = plt.hist((fit_img * ierr)[ierr > 0], range=(-6,6), bins=100)
+            plt.xlabel('Image pixel chi')
+            xx = np.linspace(-6,6, 100)
+            yy = 1./np.sqrt(2.*np.pi) * np.exp(-0.5 * xx**2)
+            yy *= sum(n)
+            db = b[1]-b[0]
+            plt.plot(xx, yy * db, 'r-')
+            plt.xlim(-6,6)
+            fn = 'chi-%i-%s.png' % (self.expnum, self.ccdname)
+            plt.savefig(fn)
+            print('Wrote', fn)
+
+            plt.clf()
+            I = (ierr > 0) * (fit_img > 1)
+            plt.hexbin(fit_img[I], 1. / ierr[I],
+                       xscale='log', yscale='log')
+            plt.xlabel('Image pixel value')
+            plt.ylabel('Uncertainty')
+            fn = 'unc-%i-%s.png' % (self.expnum, self.ccdname)
+            plt.savefig(fn)
+            print('Wrote', fn)
 
             # Run tractor fitting of the PS1 stars, using the PsfEx model.
             phot = self.tractor_fit_sources(ps1.ra_ok, ps1.dec_ok, flux0,

--- a/py/legacyzpts/legacy_zeropoints.py
+++ b/py/legacyzpts/legacy_zeropoints.py
@@ -1109,21 +1109,6 @@ class Measurer(object):
         self.bitmask= self.read_bitmask()
         weight = self.read_weight()
 
-        plt.clf()
-        n,b,p = plt.hist(((self.img - np.median(self.img)) * np.sqrt(weight))[weight > 0],
-                         range=(-6,6), bins=100)
-        plt.xlabel('Image pixel chi')
-        xx = np.linspace(-6,6, 100)
-        yy = 1./np.sqrt(2.*np.pi) * np.exp(-0.5 * xx**2)
-        yy *= sum(n)
-        db = b[1]-b[0]
-        plt.plot(xx, yy * db, 'r-')
-        plt.xlim(-6,6)
-        fn = 'chipre-%i-%s.png' % (self.expnum, self.ccdname)
-        plt.savefig(fn)
-        print('Wrote', fn)
-
-
         self.invvar = self.remap_invvar(weight, self.primhdr, self.img, self.bitmask)
 
         t0= ptime('read image',t0)
@@ -1372,28 +1357,28 @@ class Measurer(object):
 
             ierr = np.sqrt(self.invvar)
 
-            plt.clf()
-            n,b,p = plt.hist((fit_img * ierr)[ierr > 0], range=(-6,6), bins=100)
-            plt.xlabel('Image pixel chi')
-            xx = np.linspace(-6,6, 100)
-            yy = 1./np.sqrt(2.*np.pi) * np.exp(-0.5 * xx**2)
-            yy *= sum(n)
-            db = b[1]-b[0]
-            plt.plot(xx, yy * db, 'r-')
-            plt.xlim(-6,6)
-            fn = 'chi-%i-%s.png' % (self.expnum, self.ccdname)
-            plt.savefig(fn)
-            print('Wrote', fn)
-
-            plt.clf()
-            I = (ierr > 0) * (fit_img > 1)
-            plt.hexbin(fit_img[I], 1. / ierr[I],
-                       xscale='log', yscale='log')
-            plt.xlabel('Image pixel value')
-            plt.ylabel('Uncertainty')
-            fn = 'unc-%i-%s.png' % (self.expnum, self.ccdname)
-            plt.savefig(fn)
-            print('Wrote', fn)
+            # plt.clf()
+            # n,b,p = plt.hist((fit_img * ierr)[ierr > 0], range=(-6,6), bins=100)
+            # plt.xlabel('Image pixel chi')
+            # xx = np.linspace(-6,6, 100)
+            # yy = 1./np.sqrt(2.*np.pi) * np.exp(-0.5 * xx**2)
+            # yy *= sum(n)
+            # db = b[1]-b[0]
+            # plt.plot(xx, yy * db, 'r-')
+            # plt.xlim(-6,6)
+            # fn = 'chi-%i-%s.png' % (self.expnum, self.ccdname)
+            # plt.savefig(fn)
+            # print('Wrote', fn)
+            # 
+            # plt.clf()
+            # I = (ierr > 0) * (fit_img > 1)
+            # plt.hexbin(fit_img[I], 1. / ierr[I],
+            #            xscale='log', yscale='log')
+            # plt.xlabel('Image pixel value')
+            # plt.ylabel('Uncertainty')
+            # fn = 'unc-%i-%s.png' % (self.expnum, self.ccdname)
+            # plt.savefig(fn)
+            # print('Wrote', fn)
 
             # Run tractor fitting of the PS1 stars, using the PsfEx model.
             phot = self.tractor_fit_sources(ps1.ra_ok, ps1.dec_ok, flux0,

--- a/py/legacyzpts/legacy_zeropoints.py
+++ b/py/legacyzpts/legacy_zeropoints.py
@@ -1163,7 +1163,7 @@ class Measurer(object):
         except OSError:
             txt="outside PS1 footprint,In Gal. Plane"
             print(txt)
-            return self.return_on_error(mess,ccds=ccds)
+            return self.return_on_error(txt,ccds=ccds)
         assert(len(ps1_gaia.columns()) > len(ps1.columns())) 
         ps1band = ps1cat.ps1band[self.band]
         # PS1 cuts

--- a/py/legacyzpts/legacy_zeropoints.py
+++ b/py/legacyzpts/legacy_zeropoints.py
@@ -142,6 +142,7 @@ def _ccds_table(camera='decam'):
         ('cd2_2', '>f4'),
         ('pixscale', 'f4'),   
         ('zptavg', '>f4'),   
+        ('yshift', 'bool'),
         # -- CCD-level quantities --
         ('ra', '>f8'),        
         ('dec', '>f8'),      
@@ -256,7 +257,7 @@ def cols_for_legacypipe_table(which='all'):
                            'ccdphrms',
                            'cd1_1','cd2_2','cd1_2','cd2_1',
                            'crval1','crval2','crpix1','crpix2']
-        dustins_keys= ['skyrms', 'sig1']
+        dustins_keys= ['skyrms', 'sig1', 'yshift']
     elif which == 'numeric':
         need_arjuns_keys= ['ra','dec','ra_bore','dec_bore',
                            'expnum',
@@ -1020,6 +1021,7 @@ class Measurer(object):
         ccds['airmass'] = self.airmass
         ccds['gain'] = self.gain
         ccds['pixscale'] = self.pixscale
+        ccds['yshift'] = 'YSHIFT' in self.primhdr
         
         # From CP Header
         hdrVal={}
@@ -2433,7 +2435,6 @@ def get_extlist(camera,fn,debug=False,choose_ccd=None):
         extlist = ['CCD1', 'CCD2', 'CCD3', 'CCD4']
         if debug:
             extlist = ['CCD1']
-            #extlist = ['CCD1','CCD2']
     elif camera == 'mosaic':
         extlist = ['CCD1', 'CCD2', 'CCD3', 'CCD4']
         if debug:

--- a/tests/test_against_idl.py
+++ b/tests/test_against_idl.py
@@ -160,39 +160,39 @@ class LoadData(object):
         assert(len(star.legacy.data) == len(star.idl.data) )
         return star
 
-  def stars_new(self,camera='decam',
-                star_table='photom',indir='ps1_gaia'):
-    """Two tables are possible, photom and astrom
+    def stars_new(self,camera='decam',
+                  star_table='photom',indir='ps1_gaia'):
+        """Two tables are possible, photom and astrom
 
-    Args:
+        Args:
         star_table: photom or astrom
         indir: the testoutput directory to read from
-    """
-    assert(camera in CAMERAS)
-    assert(star_table in ['photom','astrom'])
-    assert(indir in ['ps1_gaia','ps1_only'])
-    leg_dir= os.path.join(os.path.dirname(__file__),
-                          'testoutput',camera,
-                           indir,'against_idl')
-    print('leg_dir=%s' % leg_dir)
-    leg_fns= glob(os.path.join(leg_dir,
-                               '*%s*-star-%s.fits' % (FN_SUFFIX[camera],star_table)))
+        """
+        assert(camera in CAMERAS)
+        assert(star_table in ['photom','astrom'])
+        assert(indir in ['ps1_gaia','ps1_only'])
+        leg_dir= os.path.join(os.path.dirname(__file__),
+                              'testoutput',camera,
+                              indir,'against_idl')
+        print('leg_dir=%s' % leg_dir)
+        leg_fns= glob(os.path.join(leg_dir,
+                                   '*%s*-star-%s.fits' % (FN_SUFFIX[camera],star_table)))
 
-    idl_fns= glob(os.path.join(get_data_dir(),
-                               'good_idlzpts_data',
-                               'matches-%s*.fits' %
-                                 FN_SUFFIX[camera]))
-    assert(len(leg_fns) > 0 and len(idl_fns) > 0)
-    star= StarResiduals(camera=camera, star_table=star_table,
-                        savedir= leg_dir,
-                        leg_list=leg_fns,
-                        idl_list=idl_fns,
-                        loadable=False)
-    star.load_data()
-    star.convert_legacy()
-    star.match(ra_key='ccd_ra',dec_key='ccd_dec')
-    assert(len(star.legacy.data) == len(star.idl.data) )
-    return star
+        idl_fns= glob(os.path.join(get_data_dir(),
+                                   'good_idlzpts_data',
+                                   'matches-%s*.fits' %
+                                   FN_SUFFIX[camera]))
+        assert(len(leg_fns) > 0 and len(idl_fns) > 0)
+        star= StarResiduals(camera=camera, star_table=star_table,
+                            savedir= leg_dir,
+                            leg_list=leg_fns,
+                            idl_list=idl_fns,
+                            loadable=False)
+        star.load_data()
+        star.convert_legacy()
+        star.match(ra_key='ccd_ra',dec_key='ccd_dec')
+        assert(len(star.legacy.data) == len(star.idl.data) )
+        return star
 
 class CheckDifference(object):
     """checks that legazpts tables are sufficienlty close to idl zpts tables

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -8,6 +8,8 @@ from astrometry.util.fits import fits_table, merge_tables
 
 DOWNLOAD_DIR='http://portal.nersc.gov/project/desi/users/kburleigh/legacyzpts'
 
+DOWNLOAD_DIR_2='http://portal.nersc.gov/project/cosmo/temp/dstn/'
+
 CAMERAS= ['decam','mosaic','90prime']
 
 FN_SUFFIX= {"decam":"c4d",
@@ -27,6 +29,15 @@ def download_ccds():
                                targz), 
                   outdir)
 
+    for targz in ['ccds_decam_weights.tar.gz',
+                  'ccds_mosaic_weights.tar.gz',
+                  'ccds_90prime_weights.tar.gz',
+                  ]:
+      fetch_targz(os.path.join(DOWNLOAD_DIR_2,
+                               targz),
+                  outdir)
+
+      
 def run_and_check_outputs(image_list,cmd_line,outdir):
     """Runs legacyzpts and checks that expected files were written
 


### PR DESCRIPTION
For consistency with the legacypipe fitting, use the "oow" weight maps, and also add the invvar remapping (to downweight based on Poisson noise from the sources) as used in the legacypipe code.

Also:
- compute and save 'sig1', a per-pixel error estimate.
- save whether the 'YSHIFT' header card exists (for Mosaic3 cuts)


