### PR TITLE
Gaia DR2 and Dec<-30 fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -123,7 +123,6 @@ script:
   - export GAIA_CAT_DIR=$(pwd)/tests/testdata/chunks-gaia-dr2-astrom
   - export GAIA_CAT_VER=2
   - echo $GAIA_CAT_DIR
-  - ls $GAIA_CAT_DIR
   - pwd
   - find .
   - pytest -v tests/test_run.py::test_main 

--- a/.travis.yml
+++ b/.travis.yml
@@ -120,6 +120,10 @@ before_script:
 script:
   - pwd
   - cd $LEGACYZPTS_DIR
+  - export GAIA_CAT_DIR=$(pwd)/tests/testdata/chunks-gaia-dr2-astrom
+  - export GAIA_CAT_VER=2
+  - echo $GAIA_CAT_DIR
+  - ls $GAIA_CAT_DIR
   - pwd
   - find .
   - pytest -v tests/test_run.py::test_main 
@@ -135,7 +139,7 @@ after_success:
 cache:
   directories:
   - $HOME/legacyzpts/tests/testdata
-
+  - $HOME/build/legacysurvey/legacyzpts/tests/testdata
 
 
 

--- a/py/legacyzpts/legacy_zeropoints.py
+++ b/py/legacyzpts/legacy_zeropoints.py
@@ -883,8 +883,8 @@ class Measurer(object):
         ccds['skymag'] = skybr   # [mag/arcsec^2]
         t0= ptime('measure-sky',t0)
 
-        # Load PS1 and PS1-Gaia Catalogues 
-        # We will only used detected sources that have PS1 or PS1-gaia matches
+        # Load PS1 & Gaia catalogues
+        # We will only used detected sources that have PS1 or Gaia matches
         # So cut to this super set immediately
         
         ps1 = None

--- a/py/legacyzpts/legacy_zeropoints.py
+++ b/py/legacyzpts/legacy_zeropoints.py
@@ -366,7 +366,6 @@ class Measurer(object):
                  aper_sky_sub=False, calibrate=False, **kwargs):
         # Set extra kwargs
         self.ps1_pattern= kwargs['ps1_pattern']
-        self.ps1_only= kwargs.get('ps1_only')
         
         self.zptsfile= kwargs.get('zptsfile')
         self.prefix= kwargs.get('prefix')
@@ -2739,7 +2738,6 @@ def get_parser():
     parser.add_argument('--outdir', type=str, default='.', help='Where to write zpts/,images/,logs/')
     parser.add_argument('--debug', action='store_true', default=False, help='Write additional files and plots for debugging')
     parser.add_argument('--choose_ccd', action='store', default=None, help='forced to use only the specified ccd')
-    parser.add_argument('--ps1_only', action='store_true', default=False, help='only ps1 (not gaia) for astrometry. For photometry, only ps1 is used no matter what')
     parser.add_argument('--ps1_pattern', action='store', default='/project/projectdirs/cosmo/work/ps1/cats/chunks-qz-star-v3/ps1-%(hp)05d.fits', help='pattern for PS1 catalogues')
     parser.add_argument('--det_thresh', type=float, default=10., help='source detection, 10x sky sigma')
     parser.add_argument('--match_radius', type=float, default=1., help='arcsec, matching to gaia/ps1, 1 arcsec better astrometry than 3 arcsec as used by IDL codes')

--- a/py/legacyzpts/qa/paper_plots.py
+++ b/py/legacyzpts/qa/paper_plots.py
@@ -298,7 +298,7 @@ class ZeropointHistograms(object):
 
     def _clean(self,T):
         if 'err_message' in T.get_columns():
-            ind= pd.Series(T.get('err_message')).str.strip().str.len() == 0).values
+            ind= (pd.Series(T.get('err_message')).str.strip().str.len() == 0).values
             print('Cutting on err_message to %d/%d' % (cam,len(T[ind]),len(T)))
             T.cut(ind)
         isGrz= pd.Series(T.get('filter')).str.strip().isin(['g','r','z']).values
@@ -891,7 +891,7 @@ class ZptsTneed(object):
         self.data.cut(keep)
 
 
-def apply_cuts():
+        #def apply_cuts():
     
 
 if __name__ == '__main__':

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -108,7 +108,7 @@ def test_decam(inSurveyccds=False, ps1_only=False,
     fns= glob( patt)
     assert(len(fns) > 0)
     cmd_line=['--camera', 'decam','--outdir', outdir, 
-              '--not_on_proj', '--debug'] + extra_args #+ PS1_GAIA_ARGS
+              '--debug'] + extra_args #+ PS1_GAIA_ARGS
     run_and_check_outputs(image_list=fns, cmd_line=cmd_line,
                           outdir=outdir)
     #run_and_check_outputs(image_list=[fns[0]], cmd_line=cmd_line,
@@ -144,7 +144,7 @@ def test_mosaic(inSurveyccds=False, ps1_only=False):
                             img_patt))
     assert(len(fns) > 0)
     cmd_line=['--camera', 'mosaic','--outdir', outdir, 
-              '--not_on_proj','--debug'] + extra_args #+ PS1_GAIA_ARGS
+              '--debug'] + extra_args #+ PS1_GAIA_ARGS
     run_and_check_outputs(image_list=fns, cmd_line=cmd_line,
                           outdir=outdir)
     #run_and_check_outputs(image_list=[fns[0]], cmd_line=cmd_line,
@@ -178,7 +178,7 @@ def test_90prime(ps1_only=False):
                             img_patt))
     assert(len(fns) > 0)
     cmd_line=['--camera', '90prime','--outdir', outdir, 
-              '--not_on_proj','--debug'] + extra_args + PS1_GAIA_ARGS
+              '--debug'] + extra_args + PS1_GAIA_ARGS
     run_and_check_outputs(image_list=fns, cmd_line=cmd_line,
                           outdir=outdir)
     #run_and_check_outputs(image_list=[fns[0]], cmd_line=cmd_line,

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -15,15 +15,14 @@ CAMERAS= ['decam','mosaic','90prime']
 FN_SUFFIX= {"decam":"c4d",
             "mosaic": "k4m",
             "90prime":"bs4"}
-PS1_GAIA_ARGS= ['--ps1_pattern','tests/testdata/chunks-qz-star-v3/ps1-%(hp)05d.fits',
-                '--ps1_gaia_pattern','tests/testdata/chunks-ps1-gaia/chunk-%(hp)05d.fits']
+PS1_GAIA_ARGS= ['--ps1_pattern','tests/testdata/chunks-qz-star-v3/ps1-%(hp)05d.fits']
 
 def download_ccds():
     outdir= os.path.join(os.path.dirname(__file__),
                          'testdata')
     for targz in ['ccds_decam.tar.gz','ccds_mosaic.tar.gz',
                   'ccds_90prime.tar.gz',
-                  'chunks-qz-star-v3.tar.gz','chunks-ps1-gaia.tar.gz',
+                  'chunks-qz-star-v3.tar.gz',
                   'calib.tar.gz']:
       fetch_targz(os.path.join(DOWNLOAD_DIR,
                                targz), 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -32,6 +32,7 @@ def download_ccds():
     for targz in ['ccds_decam_weights.tar.gz',
                   'ccds_mosaic_weights.tar.gz',
                   'ccds_90prime_weights.tar.gz',
+                  'chunks-gaia-dr2.tar.gz',
                   ]:
       fetch_targz(os.path.join(DOWNLOAD_DIR_2,
                                targz),


### PR DESCRIPTION
- use Gaia DR2
- move stars to epoch of observation
- handle not having PS1 stars for photometric calibration (eg, Dec<-30)
- remove not-on-proj, copy-from-proj, ps1-only options
