### PR TITLE
additional code updates for dr8a

### DIFF
--- a/py/legacyzpts/legacy_zeropoints.py
+++ b/py/legacyzpts/legacy_zeropoints.py
@@ -355,7 +355,8 @@ class Measurer(object):
 
     def __init__(self, fn, image_dir='images', aprad=3.5, skyrad_inner=7.0,
                  skyrad_outer=10.0, det_thresh=8., match_radius=3., sn_min=None,
-                 sn_max=None, aper_sky_sub=False, calibrate=False, **kwargs):
+                 sn_max=None, aper_sky_sub=False, calibrate=False, quiet=False,
+                 **kwargs):
         # Set extra kwargs
         self.ps1_pattern= kwargs['ps1_pattern']
         
@@ -421,9 +422,10 @@ class Measurer(object):
             setattr(self, attrkey.lower(), val)
 
         self.expnum = self.get_expnum(self.primhdr)
-        print('CP Header: EXPNUM = ',self.expnum)
-        print('CP Header: PROCDATE = ',self.procdate)
-        print('CP Header: PLVER = ',self.plver)
+        if not quiet:
+            print('CP Header: EXPNUM = ',self.expnum)
+            print('CP Header: PROCDATE = ',self.procdate)
+            print('CP Header: PLVER = ',self.plver)
         self.obj = self.primhdr['OBJECT']
 
     def get_good_image_subregion(self):
@@ -2850,6 +2852,7 @@ def get_parser():
                         help='if None will use LEGACY_SURVEY_DIR/calib, e.g. /global/cscratch1/sd/desiproc/dr5-new/calib')
     parser.add_argument('--threads', default=None, type=int,
                         help='Multiprocessing threads (parallel by HDU)')
+    parser.add_argument('--quiet', default=False, action='store_true', help='quiet down')
     return parser
 
 

--- a/py/legacyzpts/legacy_zeropoints.py
+++ b/py/legacyzpts/legacy_zeropoints.py
@@ -759,7 +759,6 @@ class Measurer(object):
         if ccds is None:
             ccds= _ccds_table(self.camera)
             ccds['image_filename'] = self.fn_base
-        pdb.set_trace()
         ccds['err_message']= err_message
         ccds['zpt']= np.nan
         return ccds, stars_photom, stars_astrom
@@ -2049,7 +2048,6 @@ class Measurer(object):
         self.set_hdu(ext)
 
         ccd = FakeCCD()
-        pdb.set_trace()
         ccd.image_filename = self.fn_base
         ccd.image_hdu = self.image_hdu
         ccd.expnum = self.expnum

--- a/py/legacyzpts/legacy_zeropoints.py
+++ b/py/legacyzpts/legacy_zeropoints.py
@@ -353,9 +353,9 @@ class Measurer(object):
         aper_sky_sub: do aperture sky subtraction instead of splinesky
     """
 
-    def __init__(self, fn, aprad=3.5, skyrad_inner=7.0, skyrad_outer=10.0,
-                 det_thresh=8., match_radius=3.,sn_min=None,sn_max=None,
-                 aper_sky_sub=False, calibrate=False, **kwargs):
+    def __init__(self, fn, image_dir='images', aprad=3.5, skyrad_inner=7.0,
+                 skyrad_outer=10.0, det_thresh=8., match_radius=3., sn_min=None,
+                 sn_max=None, aper_sky_sub=False, calibrate=False, **kwargs):
         # Set extra kwargs
         self.ps1_pattern= kwargs['ps1_pattern']
         
@@ -363,7 +363,8 @@ class Measurer(object):
         self.prefix= kwargs.get('prefix')
         self.verboseplots= kwargs.get('verboseplots')
         
-        self.fn = fn
+        self.fn = os.path.join(image_dir, fn)
+        self.fn_base = fn
         self.debug= kwargs.get('debug')
         self.outdir= kwargs.get('outdir')
         self.calibdir = kwargs.get('calibdir')
@@ -388,10 +389,10 @@ class Measurer(object):
         self.nominal_fwhm = 5.0 # [pixels]
         
         try:
-            self.primhdr = read_primary_header(fn)
+            self.primhdr = read_primary_header(self.fn)
         except ValueError:
             # astropy can handle it
-            tmp= fits_astropy.open(fn)
+            tmp= fits_astropy.open(self.fn)
             self.primhdr= tmp[0].header
             tmp.close()
             del tmp
@@ -755,7 +756,8 @@ class Measurer(object):
         assert(len(err_message) > 0 & len(err_message) <= 30)
         if ccds is None:
             ccds= _ccds_table(self.camera)
-            ccds['image_filename'] = self.fn
+            ccds['image_filename'] = self.fn_base
+        pdb.set_trace()
         ccds['err_message']= err_message
         ccds['zpt']= np.nan
         return ccds, stars_photom, stars_astrom
@@ -780,7 +782,7 @@ class Measurer(object):
         # Initialize 
         ccds = _ccds_table(self.camera)
         # FIXME -- could clean up paths here??
-        ccds['image_filename'] = self.fn
+        ccds['image_filename'] = self.fn_base
         ccds['image_hdu'] = self.image_hdu 
         ccds['ccdnum'] = self.ccdnum 
         ccds['camera'] = self.camera
@@ -2045,7 +2047,8 @@ class Measurer(object):
         self.set_hdu(ext)
 
         ccd = FakeCCD()
-        ccd.image_filename = self.fn
+        pdb.set_trace()
+        ccd.image_filename = self.fn_base
         ccd.image_hdu = self.image_hdu
         ccd.expnum = self.expnum
         ccd.ccdname = self.ccdname
@@ -2500,8 +2503,7 @@ def _measure_image(args):
     '''Utility function to wrap measure_image function for multiprocessing map.''' 
     return measure_image(*args)
 
-def measure_image(img_fn, run_calibs_only=False,
-                  just_measure=False,
+def measure_image(img_fn, image_dir='images', run_calibs_only=False, just_measure=False,
                   survey=None, threads=None, **measureargs):
     '''Wrapper on the camera-specific classes to measure the CCD-level data on all
     the FITS extensions for a given set of images.
@@ -2509,13 +2511,15 @@ def measure_image(img_fn, run_calibs_only=False,
     from astrometry.util.multiproc import multiproc
     t0 = Time()
 
+    img_fn_full = os.path.join(image_dir, img_fn)
+
     # Fitsio can throw error: ValueError: CONTINUE not supported
     try:
         #print('img_fn=%s' % img_fn)
-        primhdr = read_primary_header(img_fn)
+        primhdr = read_primary_header(img_fn_full)
     except ValueError:
         # astropy can handle it
-        tmp = fits_astropy.open(img_fn)
+        tmp = fits_astropy.open(img_fn_full)
         primhdr = tmp[0].header
         tmp.close()
         del tmp
@@ -2526,18 +2530,18 @@ def measure_image(img_fn, run_calibs_only=False,
     assert(camera in camera_check or camera_check in camera)
     
     if camera == 'decam':
-        measure = DecamMeasurer(img_fn, **measureargs)
+        measure = DecamMeasurer(img_fn, image_dir=image_dir, **measureargs)
     elif camera == 'mosaic':
-        measure = Mosaic3Measurer(img_fn, **measureargs)
+        measure = Mosaic3Measurer(img_fn, image_dir=image_dir, **measureargs)
     elif camera == '90prime':
-        measure = NinetyPrimeMeasurer(img_fn, **measureargs)
+        measure = NinetyPrimeMeasurer(img_fn, image_dir=image_dir, **measureargs)
     elif camera == 'megaprime':
-        measure = MegaPrimeMeasurer(img_fn, **measureargs)
+        measure = MegaPrimeMeasurer(img_fn, image_dir=image_dir, **measureargs)
         
     if just_measure:
         return measure
 
-    extlist = get_extlist(camera, img_fn, 
+    extlist = get_extlist(camera, measure.fn, 
                           debug=measureargs['debug'],
                           choose_ccd=measureargs['choose_ccd'])
 
@@ -2663,7 +2667,7 @@ def run_one_ext(X):
     return rtns
 
 class outputFns(object):
-    def __init__(self, imgfn, outdir, camera, debug=False):
+    def __init__(self, imgfn, outdir, camera, image_dir='images', debug=False):
         """Assigns filename, makes needed dirs
 
         Args:
@@ -2682,13 +2686,14 @@ class outputFns(object):
             outdir/decam/DECam_CP/CP20151226/img_fn-star%s.fits
         """
         self.imgfn = imgfn
+        self.image_dir = image_dir
 
         # Keep the last directory component
-        dirname = os.path.basename(os.path.dirname(imgfn))
+        dirname = os.path.basename(os.path.dirname(self.imgfn))
         basedir = os.path.join(outdir, camera, dirname)
         trymakedirs(basedir)
 
-        basename = os.path.basename(imgfn) 
+        basename = os.path.basename(self.imgfn) 
         # zpt,star fns
         base = basename
         if base.endswith('.fz'):
@@ -2814,6 +2819,7 @@ def get_parser():
     parser.add_argument('--camera',choices=['decam','mosaic','90prime','megaprime'],action='store',required=True)
     parser.add_argument('--image',action='store',default=None,help='relative path to image starting from decam,bok,mosaicz dir',required=False)
     parser.add_argument('--image_list',action='store',default=None,help='text file listing multiples images in same was as --image',required=False)
+    parser.add_argument('--image_dir', type=str, default='images', help='Directory containing the imaging data (analogous to legacypipe.LegacySurveyData.image_dir).')
     parser.add_argument('--outdir', type=str, default='.', help='Where to write zpts/,images/,logs/')
     parser.add_argument('--debug', action='store_true', default=False, help='Write additional files and plots for debugging')
     parser.add_argument('--choose_ccd', action='store', default=None, help='forced to use only the specified ccd')
@@ -2873,9 +2879,10 @@ def main(image_list=None,args=None):
 
     psf = measureargs['psf']
     camera = measureargs['camera']
+    image_dir = measureargs['image_dir']
 
     survey = FakeLegacySurveyData()
-    survey.imagedir = ''
+    survey.imagedir = image_dir
     survey.calibdir = measureargs.get('calibdir')
     measureargs.update(survey=survey)
 
@@ -2906,11 +2913,11 @@ def main(image_list=None,args=None):
     t0 = ptime('parse-args', t0)
     for ii, imgfn in enumerate(image_list):
         print('Working on image {}/{}: {}'.format(ii+1, nimage, imgfn))
-        
-        # Check if the outputs are done and have the correct data model.
-        F = outputFns(imgfn, outdir, camera, debug=measureargs['debug'])
 
-        measure = measure_image(imgfn, just_measure=True, **measureargs)
+        # Check if the outputs are done and have the correct data model.
+        F = outputFns(imgfn, outdir, camera, image_dir=image_dir, debug=measureargs['debug'])
+
+        measure = measure_image(F.imgfn, just_measure=True, **measureargs)
 
         legok,annok = [validate_procdate_plver(fn, 'table', measure.expnum,
                                                measure.plver, measure.procdate)

--- a/py/legacyzpts/legacy_zeropoints_merge.py
+++ b/py/legacyzpts/legacy_zeropoints_merge.py
@@ -119,7 +119,8 @@ if __name__ == "__main__":
     else:
         cats=[]
         for cnt,fn in enumerate(fns):
-            print('Reading %d/%d' % (cnt,len(fns)))
+            if (cnt % 500) == 0:
+                print('Reading CCDs table %d/%d' % (cnt,len(fns)))
             t = fits_table(fn)
             cats.append(t)
         cats= merge_tables(cats, columns='fillzero')


### PR DESCRIPTION
Some minor updates to streamline the process of running calibrations for `DR8a` (=the test regions).

The main update is to look for images in the `images` folder, the way `legacypipe` expects (without changing the path written out to the `survey-ccds` and `annotated-ccds` tables).  This minor change will allow both `legacyzpts` and `legacypipe` to be run from the same directory -- wowza!

Another update is to write out `-survey.fits` files not `-legacypipe.fits` files.

Not yet ready to merge.